### PR TITLE
Fixes #4 - SourceDirectorySet methods are properly available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
+/.env
+/.vagrant/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ cache:
     - $HOME/.gradle/wrapper/
     - $HOME/.m2
 
+branches:
+  only:
+  - master
+
 notifications:
   email:
     on_success: change

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # assertj-generator-gradle-plugin
 
 [![Linux Build Status](https://travis-ci.org/Nava2/assertj-generator-gradle-plugin.svg?branch=master)](https://travis-ci.org/Nava2/assertj-generator-gradle-plugin)
-[![Windows Build status](https://ci.appveyor.com/api/projects/status/ia2ki6wprow9ysnl?svg=true)](https://ci.appveyor.com/project/Nava2/assertj-generator-gradle-plugin)
+[![Windows status](https://ci.appveyor.com/api/projects/status/ia2ki6wprow9ysnl/branch/master?svg=true)](https://ci.appveyor.com/project/Nava2/assertj-generator-gradle-plugin/branch/master)
 
 This is the source for the Gradle plugin for the 
 [AssertJ Generator](http://joel-costigliola.github.io/assertj/assertj-assertions-generator.html). This plugin leverages

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,95 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Copyright 2017. assertj-generator-gradle-plugin contributors.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# This vagrantfile is used for creating a ubuntu wily environment for testing changes on Linux
+
+require 'dotenv'
+
+Dotenv.load
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial64"
+
+  cpu_count   = ENV.has_key?("CPUS") ? ENV["CPUS"] : 1
+  memory_size = ENV.has_key?("MEMORY") ? ENV["MEMORY"] : 1024
+  vram_size   = ENV.has_key?("VRAM") ? ENV["VRAM"] : 64
+
+  with_gui    = ENV.has_key?("WITH_GUI") ? (ENV["WITH_GUI"]) : false
+  with_gui    = with_gui == "true" || with_gui == "1"
+
+  puts ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+  puts "Hardware Configuration:"
+  puts "\tCPUS\t\t= #{cpu_count}"
+  puts "\tRAM\t\t= #{memory_size}"
+  puts "\tVRAM\t\t= #{vram_size}"
+  puts "\tGUI\t\t= #{with_gui}"
+  puts ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n"
+
+  config.vm.provider "virtualbox" do |vb|
+
+    vb.cpus = cpu_count
+    vb.memory = memory_size
+
+    vb.customize ["modifyvm", :id, "--uartmode1", "file", "procsim-xenial.log" ]
+
+    vb.gui = with_gui
+    if with_gui
+      vb.customize ["modifyvm", :id, "--vram", vram_size]
+    end
+  end
+
+  # Install/update prerequisite software:
+
+  config.vm.provision "shell", privileged: false,
+    inline: "sed -i '1i force_color_prompt=yes' ~/.bashrc"
+
+  config.vm.provision "shell", privileged: true, inline: <<-EOF
+    apt-get update -qq
+    apt-get dist-upgrade -y -q
+  EOF
+
+  config.vm.provision "shell", privileged: true, inline: <<-EOF
+    echo "Installing oraclejdk8"
+    add-apt-repository ppa:webupd8team/java  -y
+    apt-get update -qq
+    echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+    echo debconf shared/accepted-oracle-license-v1-1 seen true   | /usr/bin/debconf-set-selections
+    apt-get install --yes oracle-java8-installer
+    yes "" | apt-get -f install
+
+    echo "Installing git"
+    apt-get install -q -y git
+  EOF
+
+  if ENV.has_key?("WORKSPACE")
+    WORKSPACE = ENV["WORKSPACE"]
+    config.vm.provision "shell", run: "always", inline: "echo 'Linking workspace: ~/workspace -> #{WORKSPACE}'"
+
+    config.vm.synced_folder WORKSPACE, "/home/vagrant/workspace"
+  end
+
+  if with_gui
+    config.vm.provision "shell", privileged: true, inline: <<-EOF
+      apt-get install -y -q kdevelop konsole
+      apt-get install -y -q ubuntu-desktop --no-install-recommends
+      apt-get install -y -q unity evince unity-lens-files unity-lens-applications
+    EOF
+  end
+
+  # Do this last since it's best to make sure everyone else is updated first
+  config.vm.provision "shell", privileged: true, inline: "apt-get dist-upgrade -y ; apt-get autoremove --purge -y"
+
+  if (Vagrant.has_plugin?('vagrant-reload'))
+    config.vm.provision :reload
+  end
+end # end vagrant file

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,5 @@ notifications:
     to:
       - '{{commitAuthorEmail}}'
 
-    settings:
-      on_build_status_changed: true
-      on_build_failure: true
+    on_build_status_changed: true
+    on_build_failure: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,15 @@ cache:
   - C:\Users\appveyor\.gradle
   - C:\Users\appveyor\.m2
 
+branches:
+  only:
+  - master
+
 notifications:
   - provider: Email
     to:
       - '{{commitAuthorEmail}}'
+
     settings:
       on_build_status_changed: true
       on_build_failure: true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip

--- a/src/main/groovy/org/assertj/generator/gradle/internal/tasks/DefaultAssertJGeneratorSourceSet.groovy
+++ b/src/main/groovy/org/assertj/generator/gradle/internal/tasks/DefaultAssertJGeneratorSourceSet.groovy
@@ -18,8 +18,11 @@ import org.assertj.generator.gradle.tasks.AssertJGeneratorSourceSet
 import org.assertj.generator.gradle.tasks.config.AssertJGeneratorOptions
 import org.assertj.generator.gradle.tasks.config.EntryPointGeneratorOptions
 import org.assertj.generator.gradle.tasks.config.Templates
+import org.gradle.api.Action
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.file.SourceDirectorySetFactory
+import org.gradle.api.internal.tasks.DefaultSourceSet
+import org.gradle.api.tasks.SourceSet
 import org.gradle.util.ConfigureUtil
 
 /**
@@ -36,10 +39,10 @@ class DefaultAssertJGeneratorSourceSet extends DefaultAssertJGeneratorOptions im
 
     private final SourceDirectorySet assertJDirectorySet
 
-    DefaultAssertJGeneratorSourceSet(String name, SourceDirectorySetFactory sourceDirectorySetFactory) {
+    DefaultAssertJGeneratorSourceSet(SourceSet sourceSet, SourceDirectorySetFactory sourceDirectorySetFactory) {
         super()
-        this.name = name
-        this.assertJDirectorySet = sourceDirectorySetFactory.create(name + " AssertJ Sources")
+        this.name = sourceSet.name
+        this.assertJDirectorySet = sourceDirectorySetFactory.create("${((DefaultSourceSet)sourceSet).displayName} AssertJ Sources")
 
         // We default to the java directory
         assertJ.srcDirs = ["src/${name}/java"]
@@ -59,13 +62,24 @@ class DefaultAssertJGeneratorSourceSet extends DefaultAssertJGeneratorOptions im
     SourceDirectorySet getAssertJ() {
         assertJDirectorySet
     }
+    
+    
 
     @Override
     AssertJGeneratorSourceSet assertJ(Closure configureClosure) {
         // turn on the plugin
         this.skip = false
 
-        ConfigureUtil.configure(configureClosure, this)
+        ConfigureUtil.configure(configureClosure, assertJ)
+        this
+    }
+
+    @Override
+    AssertJGeneratorSourceSet assertJ(Action<? super SourceDirectorySet> action) {
+        // turn on for this source set
+        this.skip = false
+
+        action.execute(assertJ)
         this
     }
 

--- a/src/main/groovy/org/assertj/generator/gradle/internal/tasks/config/DefaultAssertJGeneratorOptions.groovy
+++ b/src/main/groovy/org/assertj/generator/gradle/internal/tasks/config/DefaultAssertJGeneratorOptions.groovy
@@ -33,17 +33,13 @@ import java.nio.file.Paths
 @EqualsAndHashCode @ToString
 class DefaultAssertJGeneratorOptions implements AssertJGeneratorOptions, Serializable {
 
-    boolean skip
+    boolean skip = true
     Boolean hierarchical = null
     final Templates templates = new Templates()
     String entryPointClassPackage
     protected EntryPointGeneratorOptions _entryPoints
 
     protected String outputDir
-
-    DefaultAssertJGeneratorOptions() {
-        this.skip = true
-    }
 
     Path getOutputDir(SourceSet sourceSet) {
         if (!outputDir) return null

--- a/src/main/groovy/org/assertj/generator/gradle/tasks/AssertJGeneratorSourceSet.groovy
+++ b/src/main/groovy/org/assertj/generator/gradle/tasks/AssertJGeneratorSourceSet.groovy
@@ -12,14 +12,16 @@
  */
 package org.assertj.generator.gradle.tasks
 
-import org.assertj.generator.gradle.tasks.config.AssertJGeneratorOptions
+import org.gradle.api.Action
 import org.gradle.api.file.SourceDirectorySet
 
 /**
  * Source Set implementation used to allow definition within the JavaPlugin's
- * Source sets. This does not extends {@link org.gradle.api.tasks.SourceSet}.
+ * Source sets. This does not extend {@link org.gradle.api.tasks.SourceSet}.
  */
-interface AssertJGeneratorSourceSet extends AssertJGeneratorOptions {
+interface AssertJGeneratorSourceSet {
+
+    String NAME = "assertJ"
 
     /**
      * The name of this source set (e.g. main or test)
@@ -39,4 +41,6 @@ interface AssertJGeneratorSourceSet extends AssertJGeneratorOptions {
      * @return Umple source, never {@code null}
      */
     AssertJGeneratorSourceSet assertJ(Closure configureClosure)
+
+    AssertJGeneratorSourceSet assertJ(Action<? super SourceDirectorySet> action)
 }

--- a/src/main/groovy/org/assertj/generator/gradle/tasks/config/AssertJGeneratorOptions.java
+++ b/src/main/groovy/org/assertj/generator/gradle/tasks/config/AssertJGeneratorOptions.java
@@ -31,7 +31,6 @@ import org.gradle.util.ConfigureUtil;
  */
 public interface AssertJGeneratorOptions {
 
-    String NAME = "assertJ";
     String SOURCE_SET_NAME_TAG = "${sourceSet.testName}";
 
     /**

--- a/src/test/groovy/org/assertj/generator/gradle/IncrementalBuild.groovy
+++ b/src/test/groovy/org/assertj/generator/gradle/IncrementalBuild.groovy
@@ -114,8 +114,8 @@ class IncrementalBuild {
 
         def firstBuild = runner.build()
 
-        firstBuild.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
-        firstBuild.task(':test').outcome == TaskOutcome.SUCCESS
+        assert firstBuild.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
+        assert firstBuild.task(':test').outcome == TaskOutcome.SUCCESS
 
         // get files
         def times = assertFiles("main", true).collect {
@@ -123,8 +123,8 @@ class IncrementalBuild {
         }
 
         def secondBuild = runner.build()
-        secondBuild.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
-        secondBuild.task(':test').outcome == TaskOutcome.SUCCESS
+        assert secondBuild.task(':generateAssertJ').outcome == TaskOutcome.UP_TO_DATE
+        assert secondBuild.task(':test').outcome == TaskOutcome.UP_TO_DATE
 
         def newFiles = assertFiles("main", true)
 
@@ -152,8 +152,8 @@ class IncrementalBuild {
 
         def firstBuild = runner.build()
 
-        firstBuild.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
-        firstBuild.task(':test').outcome == TaskOutcome.SUCCESS
+        assert firstBuild.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
+        assert firstBuild.task(':test').outcome == TaskOutcome.SUCCESS
 
         // get files
         def files = assertFiles("main", true)
@@ -171,8 +171,11 @@ class IncrementalBuild {
         h1Java << "\n// some changed data"
 
         def secondBuild = runner.build()
-        secondBuild.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
-        secondBuild.task(':test').outcome == TaskOutcome.SUCCESS
+        // Make sure it did run
+        assert secondBuild.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
+
+        // However, since we didn't actually change anything, there's nothing to test, thus UP_TO_DATE
+        assert secondBuild.task(':test').outcome == TaskOutcome.UP_TO_DATE
 
         assertFiles("main", true)
 

--- a/src/test/groovy/org/assertj/generator/gradle/SimpleBuild.groovy
+++ b/src/test/groovy/org/assertj/generator/gradle/SimpleBuild.groovy
@@ -59,6 +59,16 @@ class SimpleBuild {
             }
             """.stripIndent()
 
+        File otherWorldJava = srcPackagePath.resolve('OtherWorld.java').toFile()
+
+        otherWorldJava << """
+            package org.example;
+            
+            public final class OtherWorld {
+                public boolean isBrainy = false;
+            }
+            """.stripIndent()
+
         File testDir = testProjectDir.newFolder('src', 'test', 'java')
 
         testDir.toPath().resolve(packagePath).toFile().mkdirs()
@@ -124,9 +134,34 @@ class SimpleBuild {
                 .withArguments('-i', '-s', 'test')
                 .build()
 
-        result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
-        result.task(':test').outcome == TaskOutcome.SUCCESS
+        assert result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
+        assert result.task(':test').outcome == TaskOutcome.SUCCESS
 
+    }
+
+    @Test
+    void exclude_class() {
+
+        TestUtils.buildFile(buildFile, """
+            sourceSets {
+                main {
+                    assertJ {
+                        exclude '**/org/example/OtherWorld*'
+                    }
+                }
+            }
+        """)
+
+        def result = GradleRunner.create()
+                .withGradleVersion("3.5")
+                .withProjectDir(testProjectDir.root)
+                .withDebug(true)
+                .withPluginClasspath()
+                .withArguments('-i', '-s', 'test')
+                .build()
+
+        assert result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
+        assert result.task(':compileTestJava').outcome == TaskOutcome.SUCCESS
     }
 
 

--- a/src/test/groovy/org/assertj/generator/gradle/parameter/ConfigureGeneration.groovy
+++ b/src/test/groovy/org/assertj/generator/gradle/parameter/ConfigureGeneration.groovy
@@ -12,6 +12,7 @@
  */
 package org.assertj.generator.gradle.parameter
 
+import org.assertj.generator.gradle.TestUtils
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Before
@@ -62,10 +63,7 @@ class ConfigureGeneration {
     void change_generate_from_sourceSet() {
 
 
-        buildFile << """
-            // Add required plugins and source sets to the sub projects
-            plugins { id "net.navatwo.assertj.generator.gradle.plugin" } // Note must use this syntax
-            
+        TestUtils.buildFile(buildFile, """
             sourceSets {
                 main {
                     assertJ {
@@ -77,22 +75,7 @@ class ConfigureGeneration {
                     }
                 }
             }
-            
-            // add some classpath dependencies
-            repositories {
-                mavenCentral()
-            }
-                        
-            dependencies {
-                // https://mvnrepository.com/artifact/com.google.guava/guava
-                compile group: 'com.google.guava', name: 'guava', version: '20.0'
-                
-                // https://mvnrepository.com/artifact/org.assertj/assertj-core
-                testCompile group: 'org.assertj', name: 'assertj-core', version: '3.8.0'
-                
-                testCompile group: 'junit', name: 'junit', version: '4.12'
-            }
-        """.stripMargin()
+        """)
 
         def result = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
@@ -101,8 +84,8 @@ class ConfigureGeneration {
                 .withArguments('-i', '-s', 'test')
                 .build()
 
-        result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
-        result.task(':test').outcome == TaskOutcome.SUCCESS
+        assert result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
+        assert result.task(':test').outcome == TaskOutcome.SUCCESS
 
         Path generatedPackage = testProjectDir.root.toPath()
                 .resolve("build/generated-src/test/java")
@@ -122,9 +105,7 @@ class ConfigureGeneration {
     @Test
     void change_generate_from_global() {
 
-        buildFile << """
-            plugins { id "net.navatwo.assertj.generator.gradle.plugin" } 
-
+        TestUtils.buildFile(buildFile, """
             assertJ {
                 entryPoints = ['bdd']
             }
@@ -134,22 +115,7 @@ class ConfigureGeneration {
                     assertJ { }
                 }
             }
-            
-            // add some classpath dependencies
-            repositories {
-                mavenCentral()
-            }
-                        
-            dependencies {
-                // https://mvnrepository.com/artifact/com.google.guava/guava
-                compile group: 'com.google.guava', name: 'guava', version: '20.0'
-                
-                // https://mvnrepository.com/artifact/org.assertj/assertj-core
-                testCompile group: 'org.assertj', name: 'assertj-core', version: '3.8.0'
-                
-                testCompile group: 'junit', name: 'junit', version: '4.12'
-            }
-        """.stripMargin()
+        """)
 
         def result = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
@@ -158,8 +124,8 @@ class ConfigureGeneration {
                 .withArguments('-i', '-s', 'test')
                 .build()
 
-        result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
-        result.task(':test').outcome == TaskOutcome.SUCCESS
+        assert result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
+        assert result.task(':test').outcome == TaskOutcome.SUCCESS
 
         Path generatedPackage = testProjectDir.root.toPath()
                 .resolve("build/generated-src/test/java")

--- a/src/test/groovy/org/assertj/generator/gradle/parameter/OutputDirParameter.groovy
+++ b/src/test/groovy/org/assertj/generator/gradle/parameter/OutputDirParameter.groovy
@@ -84,8 +84,8 @@ class OutputDirParameter {
                 .withArguments('-i', '-s', 'test')
                 .build()
 
-        result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
-        result.task(':test').outcome == TaskOutcome.SUCCESS
+        assert result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
+        assert result.task(':test').outcome == TaskOutcome.SUCCESS
 
         assertFiles("main", true)
     }
@@ -114,8 +114,8 @@ class OutputDirParameter {
                 .withArguments('-i', '-s', 'test')
                 .build()
 
-        result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
-        result.task(':test').outcome == TaskOutcome.SUCCESS
+        assert result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
+        assert result.task(':test').outcome == TaskOutcome.SUCCESS
 
         assertFiles("main", true)
     }

--- a/src/test/groovy/org/assertj/generator/gradle/parameter/SkipParameter.groovy
+++ b/src/test/groovy/org/assertj/generator/gradle/parameter/SkipParameter.groovy
@@ -90,11 +90,11 @@ class SkipParameter {
                 .withProjectDir(testProjectDir.root)
                 .withDebug(true)
                 .withPluginClasspath()
-                .withArguments('-i', '-s', 'test')
+                .withArguments('-i', '-s', 'build')
                 .build()
 
-        result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
-        result.task(':test').outcome == TaskOutcome.SUCCESS
+        assert result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
+        assert result.task(':build').outcome == TaskOutcome.SUCCESS
 
         assertFiles("main", false)
     }
@@ -120,8 +120,8 @@ class SkipParameter {
                 .withArguments('-i', '-s', 'test')
                 .build()
 
-        result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
-        result.task(':test').outcome == TaskOutcome.SUCCESS
+        assert result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
+        assert result.task(':test').outcome == TaskOutcome.SUCCESS
 
         assertFiles("main", true)
     }

--- a/src/test/groovy/org/assertj/generator/gradle/parameter/TemplateChanges.groovy
+++ b/src/test/groovy/org/assertj/generator/gradle/parameter/TemplateChanges.groovy
@@ -12,6 +12,7 @@
  */
 package org.assertj.generator.gradle.parameter
 
+import org.assertj.generator.gradle.TestUtils
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Before
@@ -66,10 +67,7 @@ class TemplateChanges {
     @Test
     void change_default_template_from_sourceSet() {
 
-        buildFile << """
-            // Add required plugins and source sets to the sub projects
-            plugins { id "net.navatwo.assertj.generator.gradle.plugin" } // Note must use this syntax
-            
+        TestUtils.buildFile(buildFile, """
             sourceSets {
                 main {
                     assertJ {
@@ -79,22 +77,7 @@ class TemplateChanges {
                     }
                 }
             }
-            
-            // add some classpath dependencies
-            repositories {
-                mavenCentral()
-            }
-                        
-            dependencies {
-                // https://mvnrepository.com/artifact/com.google.guava/guava
-                compile group: 'com.google.guava', name: 'guava', version: '20.0'
-                
-                // https://mvnrepository.com/artifact/org.assertj/assertj-core
-                testCompile group: 'org.assertj', name: 'assertj-core', version: '3.8.0'
-                
-                testCompile group: 'junit', name: 'junit', version: '4.12'
-            }
-        """
+        """)
 
         def result = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
@@ -103,8 +86,8 @@ class TemplateChanges {
                 .withArguments('-i', '-s', 'test')
                 .build()
 
-        result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
-        result.task(':test').outcome == TaskOutcome.SUCCESS
+        assert result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
+        assert result.task(':test').outcome == TaskOutcome.SUCCESS
 
         Path generatedAssert = testProjectDir.root.toPath()
                 .resolve("build/generated-src/test/java")
@@ -118,10 +101,7 @@ class TemplateChanges {
     @Test
     void change_default_template_from_global() {
 
-        buildFile << """
-            // Add required plugins and source sets to the sub projects
-            plugins { id "net.navatwo.assertj.generator.gradle.plugin" } // Note must use this syntax
-
+        TestUtils.buildFile(buildFile, """
             assertJ {
                 templates {
                     wholeNumberAssertion = '${TEMPLATE_CONTENT}'
@@ -133,22 +113,7 @@ class TemplateChanges {
                     assertJ { }
                 }
             }
-            
-            // add some classpath dependencies
-            repositories {
-                mavenCentral()
-            }
-                        
-            dependencies {
-                // https://mvnrepository.com/artifact/com.google.guava/guava
-                compile group: 'com.google.guava', name: 'guava', version: '20.0'
-                
-                // https://mvnrepository.com/artifact/org.assertj/assertj-core
-                testCompile group: 'org.assertj', name: 'assertj-core', version: '3.8.0'
-                
-                testCompile group: 'junit', name: 'junit', version: '4.12'
-            }
-        """
+        """)
 
         def result = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
@@ -157,8 +122,8 @@ class TemplateChanges {
                 .withArguments('-i', '-s', 'test')
                 .build()
 
-        result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
-        result.task(':test').outcome == TaskOutcome.SUCCESS
+        assert result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
+        assert result.task(':test').outcome == TaskOutcome.SUCCESS
 
         Path generatedAssert = testProjectDir.root.toPath()
                 .resolve("build/generated-src/test/java")


### PR DESCRIPTION
This fixes issues with accessing the `include` and `exclude` methods
(among others) from `SourceDirectorySet` and allows them to be used in
_local_ `assertJ` closures.

Additionally, this cleaned up some cyclic task dependencies and properly
tests build results.